### PR TITLE
Fully remove Google Analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "react": "^15.0.1",
     "react-addons-test-utils": "^15.3.2",
     "react-dom": "^15.0.1",
-    "react-ga": "^2.1.2",
     "react-redux": "^5.0.2",
     "react-router": "^3.0.0",
     "redux": "^3.5.2",

--- a/viewer/core/static/js/app/router.js
+++ b/viewer/core/static/js/app/router.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Router, Route, browserHistory } from 'react-router';
-import ReactGA from 'react-ga';
 
 // Layouts
 import MainLayout from './components/layouts/main-layout';
@@ -12,14 +11,6 @@ import ChartDetailContainer from './components/containers/chart-detail-container
 import NotFound from './components/views/not-found';
 import PermissionDenied from './components/views/permission-denied';
 
-
-// Copied from:
-// https://github.com/react-ga/react-ga#with-npm
-ReactGA.initialize(process.env.TRACKING_ID);
-function logPageView() {
-  ReactGA.set({ page: window.location.pathname });
-  ReactGA.pageview(window.location.pathname);
-}
 
 /**
  * If the path that's about to be loaded doesn't include some required query
@@ -62,7 +53,7 @@ function addDefaultChartQPs(nextState, replace) {
 }
 
 export default (
-  <Router history={browserHistory} onUpdate={logPageView}>
+  <Router history={browserHistory}>
     <Route component={AppContainer}>
       <Route component={MainLayout}>
         <Route path="/" component={Home} onEnter={addDefaultChartQPs} />

--- a/viewer/core/templates/viewer/login.html
+++ b/viewer/core/templates/viewer/login.html
@@ -18,25 +18,6 @@
         window.location.pathname = '/permission-denied/';
       </script>
     {% endif %}
-
-    {% comment %}
-      A package called react-ga is used to enable Google Analytics throughout
-      the React application. But the React application isn't loaded here on the
-      login page, so we also need to manually enable GA below.
-
-      This code doesn't need to be present in index.html because index.html
-      *does* load the React application.
-
-      TODO: Re-enable with new project GA token.
-      <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-        ga('create', 'UA-49796218-54', 'auto');
-        ga('send', 'pageview');
-      </script>
-    {% endcomment %}
   </head>
   <body id="login">
     <div id="root">

--- a/viewer/settings.py
+++ b/viewer/settings.py
@@ -131,9 +131,6 @@ GOOGLE_AUTH_KEY = config(
 GOOGLE_AUTH_SECRET = config('GOOGLE_AUTH_SECRET', '_HoDDGIq_ZrhBiES-ozIhUgh')
 GOOGLE_AUTH_HOSTED_DOMAIN = 'mozilla.com'
 
-# Google Analytics
-TRACKING_ID = config('TRACKING_ID', default=None)
-
 # Sentry set up.
 SENTRY_DSN = config('SENTRY_DSN', default=None)
 if SENTRY_DSN:

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -5,7 +5,6 @@ const plugins = [
   new webpack.DefinePlugin({
     'process.env': {
       'NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development'),
-      'TRACKING_ID': JSON.stringify(process.env.TRACKING_ID),
     }
   })
 ];


### PR DESCRIPTION
Commit 2fa3ed3 removed Google Analytics from the login page. This commit
removes it from the React application. It was easier to delete rather
than comment the lines in React, so for consistency, I also deleted the
lines from the login page.

I've opened an issue [1] to re-add Google Analytics when this project
has a unique tracking code.

[1] https://github.com/mozilla/experiments-viewer/issues/15