### PR TITLE
update chart cohorts state immediately

### DIFF
--- a/viewer/core/static/css/switch.styl
+++ b/viewer/core/static/css/switch.styl
@@ -6,6 +6,7 @@
   font-size: 12px;
   justify-content: space-between;
   line-height: 20px;
+  cursor: pointer;
 
   .handle {
     background-image: linear-gradient(-180deg, #FAFAFA 0%, #EFF1F4 100%);
@@ -24,7 +25,6 @@
   background: rgba(0,0,0,0.50);
   border-radius: 30px;
   box-shadow: inset 0 1px 5px 0 rgba(0,0,0,0.2);
-  cursor: pointer;
   height: 20px;
   margin: 0 7px;
   position: relative;

--- a/viewer/core/static/js/app/components/containers/dataset-control-container.js
+++ b/viewer/core/static/js/app/components/containers/dataset-control-container.js
@@ -28,9 +28,14 @@ class DatasetControlContainer extends React.Component {
   _handleApplyButton(evt) {
     const selectedDatasetId = parseInt(evt.target.parentNode.querySelector('.dataset-selection').value, 10);
     urlApi.updateQueryParameter('ds', selectedDatasetId);
+    urlApi.updateQueryParameter('sg', 'ALL');
+  }
 
+  // elm = switch parent element = '.switch-wrapper'
+  // available but curently unused.
+  _handleCohortSwitch(elm) {
     const selectedSubgroups = Array.from(
-        document.body.querySelectorAll('.dataset-cohorts .switch.active')
+      document.body.querySelectorAll('.dataset-cohorts .switch.active')
     ).map(ss => ss.parentNode.textContent);
     urlApi.updateQueryParameter('sg', selectedSubgroups.join(','));
   }
@@ -42,6 +47,7 @@ class DatasetControlContainer extends React.Component {
 
         handleApplyButton={this._handleApplyButton}
         handleDatasetSelection={this._handleDatasetSelection}
+        handleCohortSwitch={this._handleCohortSwitch}
 
         currentDatasetId={this.state.currentDatasetId}
       />

--- a/viewer/core/static/js/app/components/views/dataset-control.js
+++ b/viewer/core/static/js/app/components/views/dataset-control.js
@@ -20,7 +20,7 @@ export default function(props) {
         {props.currentDataset.populations.map(cohort => {
           const isActive = props.subgroupsToShow.includes(cohort);
           return (
-            <Switch key={cohort} label={cohort} active={isActive} />
+            <Switch key={cohort} label={cohort} onClick={props.handleCohortSwitch} active={isActive} />
           );
         })}
       </div>

--- a/viewer/core/static/js/app/components/views/switch.js
+++ b/viewer/core/static/js/app/components/views/switch.js
@@ -1,21 +1,37 @@
 import React from 'react';
 
 
-function toggleSwitch(evt) {
-  if (evt.target.classList.contains('switch')) {
-    evt.target.classList.toggle('active');
-  } else {
-    evt.target.parentNode.classList.toggle('active');
-  }
-}
+export default class extends React.Component {
+  constructor(props) {
+    super(props);
 
-export default function(props) {
-  return (
-    <div className="switch-wrapper" onClick={toggleSwitch}>
-      <span className={props.active ? 'switch active' : 'switch'}>
-        <b className="handle" />
-      </span>
-      {props.label ? props.label : ''}
-    </div>
-  );
+    this.toggleSwitch = this.toggleSwitch.bind(this);
+  }
+
+  toggleSwitch(evt) {
+    function getWrapper(elm) {
+      if (elm.classList.contains('switch-wrapper')) {
+        return elm;
+      }
+      return getWrapper(elm.parentNode);
+    }
+
+    let switchWrapper = getWrapper(evt.target);
+    switchWrapper.querySelector('.switch').classList.toggle('active');
+
+    // React components can only have 1 event listener (of a type) so
+    // handle the passed onClick as well.
+    this.props.onClick(switchWrapper);
+  }
+
+  render() {
+    return (
+      <div className="switch-wrapper" onClick={this.toggleSwitch}>
+        <span className={this.props.active ? 'switch active' : 'switch'}>
+          <b className="handle" />
+        </span>
+        {this.props.label ? this.props.label : ''}
+      </div>
+    );
+  }
 }


### PR DESCRIPTION
The entire switch should now respond (as opposed to just the trigger area) and we can piggyback an onClick.